### PR TITLE
makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ all:
 	@echo "Nothing to build. To run the test-suite: make check"
 
 check: node_modules
-	make -C test deploy
-	make -C test run
+	$(MAKE) -C test deploy
+	$(MAKE) -C test run
 
 node_modules: package.json
 	npm install

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,7 @@ frida_version := 9.1.1
 test_sources := $(wildcard re/frida/*.java)
 test_classes := $(patsubst %.java,%.class,$(test_sources))
 
-android_jar := $(ANDROID_SDK_ROOT)/platforms/android-23/android.jar
+android_jar := $(shell echo $(ANDROID_SDK_ROOT))/platforms/android-23/android.jar
 
 all:
 	@echo "Available targets: deploy run"

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,7 +16,7 @@ all:
 
 deploy: build/armeabi-v7a/runner build/tests.dex build/frida-java.js
 	adb shell "rm -rf $(deploy_data_dir) && mkdir -p $(deploy_data_dir)"
-	$(foreach foo, $(^), adb push $(foo) $(deploy_data_dir);)
+	adb push $^ $(deploy_data_dir)
 
 run:
 	adb shell /data/local/tmp/frida-java-tests/runner

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,14 +9,14 @@ frida_version := 9.1.1
 test_sources := $(wildcard re/frida/*.java)
 test_classes := $(patsubst %.java,%.class,$(test_sources))
 
-android_jar := $(shell echo $(ANDROID_SDK_ROOT))/platforms/android-23/android.jar
+android_jar := $(ANDROID_SDK_ROOT)/platforms/android-23/android.jar
 
 all:
 	@echo "Available targets: deploy run"
 
 deploy: build/armeabi-v7a/runner build/tests.dex build/frida-java.js
 	adb shell "rm -rf $(deploy_data_dir) && mkdir -p $(deploy_data_dir)"
-	adb push $^ $(deploy_data_dir)
+	$(foreach foo, $(^), adb push $(foo) $(deploy_data_dir))
 
 run:
 	adb shell /data/local/tmp/frida-java-tests/runner

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,7 +16,7 @@ all:
 
 deploy: build/armeabi-v7a/runner build/tests.dex build/frida-java.js
 	adb shell "rm -rf $(deploy_data_dir) && mkdir -p $(deploy_data_dir)"
-	$(foreach foo, $(^), adb push $(foo) $(deploy_data_dir))
+	$(foreach foo, $(^), adb push $(foo) $(deploy_data_dir);)
 
 run:
 	adb shell /data/local/tmp/frida-java-tests/runner


### PR DESCRIPTION
if calling `make` from a makefile, use `$(MAKE)` which allows `-j` option to work properly
`adb push` doesn work like `cp` where you can `cp src1 src2 src3 dst`.  you have to push each file individually in `build/armeabi-v7a/runner build/tests.dex build/frida-java.js`