### PR TITLE
handle field / method name collision

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -669,9 +669,13 @@ function ClassFactory (vm) {
           try {
             const fieldName = invokeObjectMethodNoArgs(env.handle, field, fieldGetName);
             try {
-              const fieldjsName = env.stringFromJni(fieldName);
+              var fieldjsName = env.stringFromJni(fieldName);
               const fieldHandle = env.newGlobalRef(field);
               fieldHandles.push(fieldHandle);
+              // If we have a collided method, suffix the fieldName
+              if(jsMethods.hasOwnProperty(fieldjsName)){
+                fieldjsName = "_" + fieldjsName;
+              }
               jsFields[fieldjsName] = fieldHandle;
             } finally {
               env.deleteLocalRef(fieldName);

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -669,11 +669,10 @@ function ClassFactory (vm) {
           try {
             const fieldName = invokeObjectMethodNoArgs(env.handle, field, fieldGetName);
             try {
-              var fieldjsName = env.stringFromJni(fieldName);
+              let fieldjsName = env.stringFromJni(fieldName);
               const fieldHandle = env.newGlobalRef(field);
               fieldHandles.push(fieldHandle);
-              // If we have a collided method, suffix the fieldName
-              if(jsMethods.hasOwnProperty(fieldjsName)){
+              while (jsMethods.hasOwnProperty(fieldjsName)){
                 fieldjsName = "_" + fieldjsName;
               }
               jsFields[fieldjsName] = fieldHandle;

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -670,11 +670,13 @@ function ClassFactory (vm) {
             const fieldName = invokeObjectMethodNoArgs(env.handle, field, fieldGetName);
             try {
               let fieldjsName = env.stringFromJni(fieldName);
-              const fieldHandle = env.newGlobalRef(field);
-              fieldHandles.push(fieldHandle);
-              while (jsMethods.hasOwnProperty(fieldjsName)){
+              while (jsMethods.hasOwnProperty(fieldjsName)) {
                 fieldjsName = "_" + fieldjsName;
               }
+
+              const fieldHandle = env.newGlobalRef(field);
+              fieldHandles.push(fieldHandle);
+              
               jsFields[fieldjsName] = fieldHandle;
             } finally {
               env.deleteLocalRef(fieldName);

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -676,7 +676,7 @@ function ClassFactory (vm) {
 
               const fieldHandle = env.newGlobalRef(field);
               fieldHandles.push(fieldHandle);
-              
+
               jsFields[fieldjsName] = fieldHandle;
             } finally {
               env.deleteLocalRef(fieldName);

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -65,7 +65,6 @@ public class MethodTest {
         assertEquals("Badger", script.getNextMessage());
     }
 
-
     @Test
     public void fieldsThatCollideWithMethodsGetSuffixed() {
         loadScript("var Collider = Java.use('re.frida.Collider');" +
@@ -177,14 +176,13 @@ class Badger {
 
 class Collider {
     static int particle = 1;
-    
     int particle2 = 2;
 
     int particle() {
         return 3;
     }
 
-    static int particle2(){
+    static int particle2() {
         return 4;
     }
 }

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -70,7 +70,7 @@ public class MethodTest {
     public void fieldsThatCollideWithMethodsGetSuffixed() {
         loadScript("var Collider = Java.use('re.frida.Collider');" +
                 "var collider = Collider.$new();" +
-                "send(collider._Particle);");
+                "send(collider._particle);");
         assertEquals("1", script.getNextMessage());
     }
 
@@ -78,7 +78,7 @@ public class MethodTest {
     public void methodsThatCollideWithFieldsKeepName() {
         loadScript("var Collider = Java.use('re.frida.Collider');" +
                 "var collider = Collider.$new();" +
-                "send(collider.Particle());");
+                "send(collider.particle());");
         assertEquals("3", script.getNextMessage());
     }
 
@@ -86,7 +86,7 @@ public class MethodTest {
     public void fieldsThatCollideWithMethodsGetSuffixed2() {
         loadScript("var Collider = Java.use('re.frida.Collider');" +
                 "var collider = Collider.$new();" +
-                "send(collider._Particle2);");
+                "send(collider._particle2);");
         assertEquals("2", script.getNextMessage());
     }
 
@@ -94,31 +94,31 @@ public class MethodTest {
     public void methodsThatCollideWithFieldsKeepName2() {
         loadScript("var Collider = Java.use('re.frida.Collider');" +
                 "var collider = Collider.$new();" +
-                "send(collider.Particle2());");
+                "send(collider.particle2());");
         assertEquals("4", script.getNextMessage());
     }
 
     @Test
     public void collidedMethodsFieldsCanStillBeInstrumented() {
         loadScript("var Collider = Java.use('re.frida.Collider');" +
-                "Collider._Particle.implementation = function () {" +
+                "Collider._particle.implementation = function () {" +
                     "return 11;" +
                 "};" +
-                "Collider._Particle2.implementation = function () {" +
+                "Collider._particle2.implementation = function () {" +
                     "return 22;" +
                 "};" +
-                "Collider.Particle.implementation = function () {" +
+                "Collider.particle.implementation = function () {" +
                     "return 33;" +
                 "};" +
-                "Collider.Particle2.implementation = function () {" +
+                "Collider.particle2.implementation = function () {" +
                     "return 44;" +
                 "};");
 
         Collider collider = new Collider();
-        assertEquals(11, Collider.Particle);
-        assertEquals(22, collider.Particle2);
-        assertEquals(33, collider.Particle());
-        assertEquals(44, Collider.Particle2());
+        assertEquals(11, Collider.particle);
+        assertEquals(22, collider.particle2);
+        assertEquals(33, collider.particle());
+        assertEquals(44, Collider.particle2());
     }
 
     // @Test
@@ -176,15 +176,15 @@ class Badger {
 }
 
 class Collider {
-    static int Particle = 1;
+    static int particle = 1;
     
-    int Particle2 = 2;
+    int particle2 = 2;
 
-    int Particle() {
+    int particle() {
         return 3;
     }
 
-    static int Particle2(){
+    static int particle2(){
         return 4;
     }
 }

--- a/test/re/frida/MethodTest.java
+++ b/test/re/frida/MethodTest.java
@@ -65,6 +65,62 @@ public class MethodTest {
         assertEquals("Badger", script.getNextMessage());
     }
 
+
+    @Test
+    public void fieldsThatCollideWithMethodsGetSuffixed() {
+        loadScript("var Collider = Java.use('re.frida.Collider');" +
+                "var collider = Collider.$new();" +
+                "send(collider._Particle);");
+        assertEquals("1", script.getNextMessage());
+    }
+
+    @Test
+    public void methodsThatCollideWithFieldsKeepName() {
+        loadScript("var Collider = Java.use('re.frida.Collider');" +
+                "var collider = Collider.$new();" +
+                "send(collider.Particle());");
+        assertEquals("3", script.getNextMessage());
+    }
+
+    @Test
+    public void fieldsThatCollideWithMethodsGetSuffixed2() {
+        loadScript("var Collider = Java.use('re.frida.Collider');" +
+                "var collider = Collider.$new();" +
+                "send(collider._Particle2);");
+        assertEquals("2", script.getNextMessage());
+    }
+
+    @Test
+    public void methodsThatCollideWithFieldsKeepName2() {
+        loadScript("var Collider = Java.use('re.frida.Collider');" +
+                "var collider = Collider.$new();" +
+                "send(collider.Particle2());");
+        assertEquals("4", script.getNextMessage());
+    }
+
+    @Test
+    public void collidedMethodsFieldsCanStillBeInstrumented() {
+        loadScript("var Collider = Java.use('re.frida.Collider');" +
+                "Collider._Particle.implementation = function () {" +
+                    "return 11;" +
+                "};" +
+                "Collider._Particle2.implementation = function () {" +
+                    "return 22;" +
+                "};" +
+                "Collider.Particle.implementation = function () {" +
+                    "return 33;" +
+                "};" +
+                "Collider.Particle2.implementation = function () {" +
+                    "return 44;" +
+                "};");
+
+        Collider collider = new Collider();
+        assertEquals(11, Collider.Particle);
+        assertEquals(22, collider.Particle2);
+        assertEquals(33, collider.Particle());
+        assertEquals(44, Collider.Particle2());
+    }
+
     // @Test
     public void interfaceCanBeImplemented() {
         loadScript("var X509TrustManager = Java.use('javax.net.ssl.X509TrustManager');" +
@@ -116,5 +172,19 @@ class Badger {
 
     public int returnZero() {
         return 0;
+    }
+}
+
+class Collider {
+    static int Particle = 1;
+    
+    int Particle2 = 2;
+
+    int Particle() {
+        return 3;
+    }
+
+    static int Particle2(){
+        return 4;
     }
 }


### PR DESCRIPTION
Allow interception when a field and a method have the same name.

note : I've added some unit tests that I wasn't able to run (no build env here)

Should fix #20 :)