### PR TITLE
Refactor to reduce global handle usage

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -50,6 +50,8 @@ function ClassFactory (vm) {
   let patchedClasses = {};
   const patchedMethods = new Set();
   let loader = null;
+  let cachedLoaderInvoke = null;
+  let cachedLoaderMethod = null;
   const FILE_PATH = Symbol('FILE_PATH');
   const PENDING_CALLS = Symbol('PENDING_CALLS');
 
@@ -80,17 +82,7 @@ function ClassFactory (vm) {
       }
     }
 
-    for (let classId in classes) {
-      if (classes.hasOwnProperty(classId)) {
-        const klass = classes[classId];
-
-        // prevent argument confusion (forEach passes not only the element but also indexes and the entire array)
-        klass.__methods__.forEach((m) => env.deleteGlobalRef(m), env);
-        klass.__fields__.forEach((f) => env.deleteGlobalRef(f), env);
-        env.deleteGlobalRef(klass.__handle__);
-        delete classes[classId];
-      }
-    }
+    classes = {};
   };
 
   Object.defineProperty(this, 'loader', {
@@ -108,19 +100,35 @@ function ClassFactory (vm) {
     if (!C) {
       const env = vm.getEnv();
       if (loader !== null) {
-        const klassObj = loader.loadClass(className);
-        C = ensureClass(klassObj.$handle, className);
-      } else {
-        const handle = env.findClass(className.replace(/\./g, '/'));
-        try {
-          C = ensureClass(handle, className);
-        } finally {
-          env.deleteLocalRef(handle);
+        const usedLoader = loader;
+
+        if (cachedLoaderMethod === null) {
+          cachedLoaderInvoke = env.vaMethod('pointer', ['pointer']);
+          cachedLoaderMethod = loader.loadClass.overload('java.lang.String').handle;
         }
+
+        const getClassHandle = function (env) {
+          const classNameValue = env.newStringUtf(className);
+          try {
+            return cachedLoaderInvoke(env.handle, usedLoader.$handle, cachedLoaderMethod, classNameValue);
+          } finally {
+            env.deleteLocalRef(classNameValue);
+          }
+        };
+
+        C = ensureClass(getClassHandle, className);
+      } else {
+        const canonicalClassName = className.replace(/\./g, '/');
+
+        const getClassHandle = function (env) {
+          return env.findClass(canonicalClassName);
+        };
+
+        C = ensureClass(getClassHandle, className);
       }
     }
 
-    return new C(C.__handle__, null);
+    return new C(null);
   };
 
   function DexFile (filePath) {
@@ -208,7 +216,11 @@ function ClassFactory (vm) {
     const addGlobalReference = api['art::JavaVMExt::AddGlobalRef'];
     const vmHandle = api.vm;
     const threadHandle = Memory.readPointer(env.handle.add(pointerSize));
-    const needle = api['art::JavaVMExt::DecodeGlobal'](api.vm, threadHandle, klass.$classHandle).toInt32();
+    const localClassHandle = klass.$getClassHandle(env);
+    const globalClassHandle = env.newGlobalRef(localClassHandle);
+    const needle = api['art::JavaVMExt::DecodeGlobal'](api.vm, threadHandle, globalClassHandle).toInt32();
+    env.deleteGlobalRef(globalClassHandle);
+    env.deleteLocalRef(localClassHandle);
 
     const collectMatchingInstanceHandles = makeObjectVisitorPredicate(needle, object => {
       instanceHandles.push(addGlobalReference(vmHandle, threadHandle, object));
@@ -320,12 +332,14 @@ function ClassFactory (vm) {
   }
 
   function chooseObjectsDalvik (className, callbacks) {
-    const env = vm.getEnv();
     const klass = factory.use(className);
 
     let enumerateInstances = function (className, callbacks) {
+      const env = vm.getEnv();
       const thread = Memory.readPointer(env.handle.add(DVM_JNI_ENV_OFFSET_SELF));
-      const ptrClassObject = api.dvmDecodeIndirectRef(thread, klass.$classHandle);
+      const classHandle = klass.$getClassHandle(env);
+      const ptrClassObject = api.dvmDecodeIndirectRef(thread, classHandle);
+      env.deleteLocalRef(classHandle);
 
       const pattern = ptrClassObject.toMatchPattern();
       const heapSourceBase = api.dvmHeapSourceGetBase();
@@ -390,47 +404,67 @@ function ClassFactory (vm) {
 
   this.cast = function (obj, klass) {
     const env = vm.getEnv();
+
     const handle = obj.hasOwnProperty('$handle') ? obj.$handle : obj;
-    if (env.isInstanceOf(handle, klass.$classHandle)) {
-      const C = klass.$classWrapper;
-      return new C(C.__handle__, handle);
-    } else {
-      throw new Error("Cast from '" + env.getObjectClassName(handle) + "' to '" + env.getClassName(klass.$classHandle) + "' isn't possible");
+
+    const classHandle = klass.$getClassHandle(env);
+    try {
+      const isValidCast = env.isInstanceOf(handle, classHandle);
+      if (!isValidCast) {
+        throw new Error("Cast from '" + env.getObjectClassName(handle) + "' to '" + env.getClassName(classHandle) + "' isn't possible");
+      }
+    } finally {
+      env.deleteLocalRef(classHandle);
     }
+
+    const C = klass.$classWrapper;
+    return new C(handle);
   };
 
   this.registerClass = registerClass;
 
-  function ensureClass (classHandle, cachedName) {
-    let env = vm.getEnv();
-
-    const name = (cachedName !== null) ? cachedName : env.getClassName(classHandle);
+  function ensureClass (getClassHandle, name) {
     let klass = classes[name];
-    if (klass) {
+    if (klass !== undefined) {
       return klass;
     }
 
-    const superHandle = env.getSuperclass(classHandle);
+    let env = vm.getEnv();
+
+    let classHandle = getClassHandle(env);
+    env.checkForExceptionAndThrowIt();
+
     let superKlass;
+    let superHandle = env.getSuperclass(classHandle);
     if (!superHandle.isNull()) {
+      const getSuperClassHandle = function (env) {
+        const classHandle = getClassHandle(env);
+        const superHandle = env.getSuperclass(classHandle);
+        env.deleteLocalRef(classHandle);
+        return superHandle;
+      };
+
       try {
-        superKlass = ensureClass(superHandle, null);
+        superKlass = ensureClass(getSuperClassHandle, env.getClassName(superHandle));
       } finally {
         env.deleteLocalRef(superHandle);
       }
     } else {
       superKlass = null;
     }
+    superHandle = null;
 
     ensureClassInitialized(env, classHandle);
 
     const simpleName = basename(name);
-    eval('klass = function ' + simpleName.replace(/^[^a-zA-Z$_]|[^a-zA-Z0-9$_]/g, '_') + '(classHandle, handle) {' + // eslint-disable-line
+    eval('klass = function ' + simpleName.replace(/^[^a-zA-Z$_]|[^a-zA-Z0-9$_]/g, '_') + '(handle) {' + // eslint-disable-line
       'var env = vm.getEnv();' +
       'this.$classWrapper = klass;' +
-      'this.$classHandle = env.newGlobalRef(classHandle);' +
-      'this.$handle = (handle !== null) ? env.newGlobalRef(handle) : null;' +
-      'this.$weakRef = WeakRef.bind(this, makeHandleDestructor(this.$handle, this.$classHandle));' +
+      'this.$getClassHandle = getClassHandle;' +
+      'if (handle !== null) {' +
+      '  this.$handle = env.newGlobalRef(handle);' +
+      '  this.$weakRef = WeakRef.bind(this, makeHandleDestructor(this.$handle));' +
+      '}' +
       '};');
 
     Object.defineProperty(klass, 'className', {
@@ -442,15 +476,18 @@ function ClassFactory (vm) {
 
     function initializeClass () {
       klass.__name__ = name;
-      klass.__handle__ = env.newGlobalRef(classHandle);
-      klass.__methods__ = [];
-      klass.__fields__ = [];
 
       let ctor = null;
       let getCtor = function (type) {
         if (ctor === null) {
           vm.perform(() => {
-            ctor = makeConstructor(klass.__handle__, vm.getEnv());
+            const env = vm.getEnv();
+            const classHandle = getClassHandle(env);
+            try {
+              ctor = makeConstructor(classHandle, env);
+            } finally {
+              env.deleteLocalRef(classHandle);
+            }
           });
         }
         if (!ctor[type]) throw new Error('assertion !ctor[type] failed');
@@ -465,8 +502,13 @@ function ClassFactory (vm) {
         get: function () {
           return function () {
             const env = vm.getEnv();
-            const obj = env.allocObject(this.$classHandle);
-            return factory.cast(obj, this);
+            const classHandle = this.$getClassHandle(env);
+            try {
+              const obj = env.allocObject(classHandle);
+              return factory.cast(obj, this);
+            } finally {
+              env.deleteLocalRef(classHandle);
+            }
           };
         }
       });
@@ -484,15 +526,30 @@ function ClassFactory (vm) {
 
       Object.defineProperty(klass.prototype, 'class', {
         get: function () {
-          const Clazz = factory.use('java.lang.Class');
-          return factory.cast(this.$classHandle, Clazz);
+          const env = vm.getEnv();
+          const classHandle = this.$getClassHandle(env);
+          try {
+            return factory.cast(classHandle, factory.use('java.lang.Class'));
+          } finally {
+            env.deleteLocalRef(classHandle);
+          }
         }
       });
 
       Object.defineProperty(klass.prototype, '$className', {
         get: function () {
           const env = vm.getEnv();
-          return this.hasOwnProperty('$handle') ? env.getObjectClassName(this.$handle) : env.getClassName(this.$classHandle);
+
+          const handle = this.$handle;
+          if (handle !== undefined)
+            return env.getObjectClassName(this.$handle);
+
+          const classHandle = this.$getClassHandle(env);
+          try {
+            return env.getClassName(classHandle);
+          } finally {
+            env.deleteLocalRef(classHandle);
+          }
         }
       });
 
@@ -501,7 +558,11 @@ function ClassFactory (vm) {
 
     function dispose () {
       /* jshint validthis: true */
-      WeakRef.unbind(this.$weakRef);
+      const ref = this.$weakRef;
+      if (ref !== undefined) {
+        delete this.$weakRef;
+        WeakRef.unbind(ref);
+      }
     }
 
     function makeConstructor (classHandle, env) {
@@ -544,32 +605,29 @@ function ClassFactory (vm) {
       };
     }
 
-    function makeField (name, handle, env) {
-      const Field = env.javaLangReflectField();
-      const Modifier = env.javaLangReflectModifier();
+    function makeField (name, params, classHandle, env) {
       const invokeObjectMethodNoArgs = env.vaMethod('pointer', []);
-      const invokeIntMethodNoArgs = env.vaMethod('int32', []);
+      const {getGenericType} = env.javaLangReflectField();
 
-      const fieldId = env.fromReflectedField(handle);
-      const modifiers = invokeIntMethodNoArgs(env.handle, handle, Field.getModifiers);
-      const jsType = (modifiers & Modifier.STATIC) !== 0 ? STATIC_FIELD : INSTANCE_FIELD;
-      const fieldType = invokeObjectMethodNoArgs(env.handle, handle, Field.getGenericType);
+      const [fieldId, jsType] = params;
 
       let jsFieldType;
+      const isStatic = jsType === STATIC_FIELD ? 1 : 0;
+      const handle = env.toReflectedField(classHandle, fieldId, isStatic);
       try {
-        jsFieldType = getTypeFromJniTypeName(env.getTypeName(fieldType));
+        const fieldType = invokeObjectMethodNoArgs(env.handle, handle, getGenericType);
+        try {
+          jsFieldType = getTypeFromJniTypeName(env.getTypeName(fieldType));
+        } finally {
+          env.deleteLocalRef(fieldType);
+        }
       } catch (e) {
         return null;
       } finally {
-        env.deleteLocalRef(fieldType);
+        env.deleteLocalRef(handle);
       }
 
-      const field = createField(name, jsType, fieldId, jsFieldType, env);
-      if (field === null) {
-        throw new Error('Unsupported field');
-      }
-
-      return field;
+      return createField(name, jsType, fieldId, jsFieldType, env);
     }
 
     function createField (name, type, targetFieldId, fieldType, env) {
@@ -581,10 +639,10 @@ function ClassFactory (vm) {
         invokeTarget = env.getField(rawFieldType);
       }
 
-      let frameCapacity = 2;
+      let frameCapacity = 3;
       const callArgs = [
         'env.handle',
-        type === INSTANCE_FIELD ? 'this.$handle' : 'this.$classHandle',
+        type === INSTANCE_FIELD ? 'this.$handle' : 'this.$getClassHandle(env)',
         'targetFieldId'
       ];
 
@@ -608,7 +666,7 @@ function ClassFactory (vm) {
 
       let getter;
       eval('getter = function get' + sanitizedName + '() {' + // eslint-disable-line
-        'var isInstance = this.$handle !== null;' +
+        'var isInstance = this.$handle !== undefined;' +
         'if (type === INSTANCE_FIELD && !isInstance) { ' +
         "throw new Error('getter of ' + name + ': cannot get an instance field without an instance.');" +
         '}' +
@@ -649,7 +707,7 @@ function ClassFactory (vm) {
 
       let setter;
       eval('setter = function set' + sanitizedName + '(value) {' + // eslint-disable-line
-        'var isInstance = this.$handle !== null;' +
+        'var isInstance = this.$handle !== undefined;' +
         'if (type === INSTANCE_FIELD && !isInstance) { ' +
         "throw new Error('setter of ' + name + ': cannot set an instance field without an instance');" +
         '}' +
@@ -676,10 +734,10 @@ function ClassFactory (vm) {
       Object.defineProperty(f, 'value', {
         enumerable: true,
         get: function () {
-          return getter.call(this.self);
+          return getter.call(this.$holder);
         },
         set: function (value) {
-          setter.call(this.self, value);
+          setter.call(this.$holder, value);
         }
       });
 
@@ -698,29 +756,17 @@ function ClassFactory (vm) {
         value: fieldType
       });
 
-      return f;
-    }
-
-    function myAssign (target, ...sources) {
-      sources.forEach(source => {
-        Object.defineProperties(target, Object.keys(source).reduce((descriptors, key) => {
-          if (key === 'holder' && target.hasOwnProperty('holder')) {
-            // there is already holder property
-          } else {
-            descriptors[key] = Object.getOwnPropertyDescriptor(source, key);
-          }
-          return descriptors;
-        }, {}));
-      });
-      return target;
+      return [f, getter, setter];
     }
 
     function addMethodsAndFields () {
+      const Modifier = env.javaLangReflectModifier();
+      const getMethodModifiers = env.javaLangReflectMethod().getModifiers;
+      const getFieldModifiers = env.javaLangReflectField().getModifiers;
       const invokeObjectMethodNoArgs = env.vaMethod('pointer', []);
+      const invokeIntMethodNoArgs = env.vaMethod('int32', []);
       const methodGetName = env.javaLangReflectMethod().getName;
       const fieldGetName = env.javaLangReflectField().getName;
-      const fieldHandles = klass.__fields__;
-      const methodHandles = klass.__methods__;
       const jsMethods = {};
       const jsFields = {};
 
@@ -732,17 +778,19 @@ function ClassFactory (vm) {
           try {
             const methodName = invokeObjectMethodNoArgs(env.handle, method, methodGetName);
             try {
-              const methodjsName = env.stringFromJni(methodName);
-              const methodHandle = env.newGlobalRef(method);
-              methodHandles.push(methodHandle);
+              const methodJsName = env.stringFromJni(methodName);
+              const methodId = env.fromReflectedMethod(method);
+              const modifiers = invokeIntMethodNoArgs(env.handle, method, getMethodModifiers);
+
               let jsOverloads;
-              if (jsMethods.hasOwnProperty(methodjsName)) {
-                jsOverloads = jsMethods[methodjsName];
-              } else {
+              if (!jsMethods.hasOwnProperty(methodJsName)) {
                 jsOverloads = [];
-                jsMethods[methodjsName] = jsOverloads;
+                jsMethods[methodJsName] = jsOverloads;
+              } else {
+                jsOverloads = jsMethods[methodJsName];
               }
-              jsOverloads.push(methodHandle);
+
+              jsOverloads.push([methodId, modifiers]);
             } finally {
               env.deleteLocalRef(methodName);
             }
@@ -762,15 +810,15 @@ function ClassFactory (vm) {
           try {
             const fieldName = invokeObjectMethodNoArgs(env.handle, field, fieldGetName);
             try {
-              let fieldjsName = env.stringFromJni(fieldName);
-              while (jsMethods.hasOwnProperty(fieldjsName)) {
-                fieldjsName = "_" + fieldjsName;
+              let fieldJsName = env.stringFromJni(fieldName);
+              while (jsMethods.hasOwnProperty(fieldJsName)) {
+                fieldJsName = '_' + fieldJsName;
               }
+              const fieldId = env.fromReflectedField(field);
+              const modifiers = invokeIntMethodNoArgs(env.handle, field, getFieldModifiers);
+              const jsType = (modifiers & Modifier.STATIC) !== 0 ? STATIC_FIELD : INSTANCE_FIELD;
 
-              const fieldHandle = env.newGlobalRef(field);
-              fieldHandles.push(fieldHandle);
-
-              jsFields[fieldjsName] = fieldHandle;
+              jsFields[fieldJsName] = [fieldId, jsType];
             } finally {
               env.deleteLocalRef(fieldName);
             }
@@ -782,53 +830,115 @@ function ClassFactory (vm) {
         env.deleteLocalRef(fields);
       }
 
-      // define access to the fields in the class (klass)
-      const values = myAssign({}, jsFields, jsMethods);
-      Object.keys(values).forEach(name => {
+      Object.keys(jsMethods).forEach(name => {
+        const overloads = jsMethods[name];
+
         let v = null;
         Object.defineProperty(klass.prototype, name, {
           get: function () {
             if (v === null) {
               vm.perform(() => {
                 const env = vm.getEnv();
-                let f = {};
-                if (jsFields.hasOwnProperty(name)) {
-                  f = makeField(name, jsFields[name], env);
+                const classHandle = getClassHandle(env);
+                try {
+                  v = makeMethodFromOverloads(name, overloads, classHandle, env);
+                } finally {
+                  env.deleteLocalRef(classHandle);
                 }
-
-                let m = {};
-                if (jsMethods.hasOwnProperty(name)) {
-                  m = makeMethodFromOverloads(name, jsMethods[name], env);
-                }
-                v = myAssign(m, f);
               });
             }
-            // TODO there should be a better way to do that
-            // set the reference for accessing fields
-            v.self = this;
 
             return v;
           }
         });
       });
+
+      Object.keys(jsFields).forEach(name => {
+        const params = jsFields[name];
+        const jsType = params[1];
+
+        let v = null;
+        Object.defineProperty(klass.prototype, name, {
+          get: function () {
+            if (v === null) {
+              vm.perform(() => {
+                const env = vm.getEnv();
+                const classHandle = getClassHandle(env);
+                try {
+                  v = makeField(name, params, classHandle, env);
+                } finally {
+                  env.deleteLocalRef(classHandle);
+                }
+
+                if (jsType === STATIC_FIELD) {
+                  v[0].$holder = this;
+                }
+              });
+            }
+
+            const [protoField, getter, setter] = v;
+
+            if (jsType === STATIC_FIELD)
+              return protoField;
+
+            if (this.$handle === undefined)
+              throw new Error('Unable to access instance field without an instance');
+
+            const field = {};
+
+            Object.defineProperties(field, {
+              value: {
+                enumerable: true,
+                get: () => {
+                  return getter.call(this);
+                },
+                set: (value) => {
+                  setter.call(this, value);
+                }
+              },
+              holder: {
+                enumerable: true,
+                value: protoField.holder
+              },
+              fieldType: {
+                enumerable: true,
+                value: protoField.fieldType
+              },
+              fieldReturnType: {
+                enumerable: true,
+                value: protoField.fieldReturnType
+              },
+            });
+
+            Object.defineProperty(this, name, {
+              enumerable: false,
+              value: field
+            });
+
+            return field;
+          }
+        });
+      });
     }
 
-    function makeMethodFromOverloads (name, overloads, env) {
+    function makeMethodFromOverloads (name, overloads, classHandle, env) {
       const Method = env.javaLangReflectMethod();
       const Modifier = env.javaLangReflectModifier();
       const invokeObjectMethodNoArgs = env.vaMethod('pointer', []);
-      const invokeIntMethodNoArgs = env.vaMethod('int32', []);
       const invokeUInt8MethodNoArgs = env.vaMethod('uint8', []);
 
-      const methods = overloads.map(function (handle) {
-        const methodId = env.fromReflectedMethod(handle);
-        const modifiers = invokeIntMethodNoArgs(env.handle, handle, Method.getModifiers);
+      const methods = overloads.map(function (params) {
+        const [methodId, modifiers] = params;
 
-        const jsType = (modifiers & Modifier.STATIC) !== 0 ? STATIC_METHOD : INSTANCE_METHOD;
-        const isVarArgs = !!invokeUInt8MethodNoArgs(env.handle, handle, Method.isVarArgs);
+        const isStatic = (modifiers & Modifier.STATIC) === 0 ? 0 : 1;
+        const jsType = isStatic ? STATIC_METHOD : INSTANCE_METHOD;
+
         let jsRetType;
         const jsArgTypes = [];
+        const handle = env.toReflectedMethod(classHandle, methodId, isStatic);
         try {
+          const isVarArgs = !!invokeUInt8MethodNoArgs(env.handle, handle, Method.isVarArgs);
+
           const retType = invokeObjectMethodNoArgs(env.handle, handle, Method.getGenericReturnType);
           env.checkForExceptionAndThrowIt();
           try {
@@ -836,6 +946,7 @@ function ClassFactory (vm) {
           } finally {
             env.deleteLocalRef(retType);
           }
+
           const argTypes = invokeObjectMethodNoArgs(env.handle, handle, Method.getGenericParameterTypes);
           env.checkForExceptionAndThrowIt();
           try {
@@ -855,6 +966,8 @@ function ClassFactory (vm) {
           }
         } catch (e) {
           return null;
+        } finally {
+          env.deleteLocalRef(handle);
         }
 
         return makeMethod(name, jsType, methodId, jsRetType, jsArgTypes, env);
@@ -923,7 +1036,7 @@ function ClassFactory (vm) {
 
       function f (...args) {
         /* jshint validthis: true */
-        const isInstance = this.$handle !== null;
+        const isInstance = this.$handle !== undefined;
         const group = candidates[args.length];
         if (!group) {
           throwOverloadError(name, methods, `argument count of ${args.length} does not match any of:`);
@@ -1069,7 +1182,7 @@ function ClassFactory (vm) {
       const argVariableNames = argTypes.map((t, i) => ('a' + (i + 1)));
       const callArgsVirtual = [
         'env.handle',
-        type === INSTANCE_METHOD ? 'this.$handle' : 'this.$classHandle',
+        type === INSTANCE_METHOD ? 'this.$handle' : 'this.$getClassHandle(env)',
         ((api.flavor === 'art') ? 'resolveArtTargetMethodId()' : 'dalvikTargetMethodId')
       ].concat(argTypes.map((t, i) => {
         if (t.toJni) {
@@ -1082,7 +1195,7 @@ function ClassFactory (vm) {
       let callArgsDirect;
       if (type === INSTANCE_METHOD) {
         callArgsDirect = callArgsVirtual.slice();
-        callArgsDirect.splice(2, 0, 'this.$classHandle');
+        callArgsDirect.splice(2, 0, 'this.$getClassHandle(env)');
       } else {
         callArgsDirect = callArgsVirtual;
       }
@@ -1286,7 +1399,7 @@ function ClassFactory (vm) {
         }
 
         const thread = Memory.readPointer(env.handle.add(DVM_JNI_ENV_OFFSET_SELF));
-        const objectPtr = api.dvmDecodeIndirectRef(thread, instance ? this.$handle : this.$classHandle);
+        const objectPtr = api.dvmDecodeIndirectRef(thread, instance ? this.$handle : this.$getClassHandle(env));
         let classObject;
         if (instance) {
           classObject = Memory.readPointer(objectPtr.add(DVM_OBJECT_OFFSET_CLAZZ));
@@ -1386,6 +1499,7 @@ function ClassFactory (vm) {
     initializeClass();
 
     // Guard against use-after-"free"
+    env.deleteLocalRef(classHandle);
     classHandle = null;
     env = null;
 
@@ -1394,148 +1508,158 @@ function ClassFactory (vm) {
 
   function registerClass (spec) {
     const env = vm.getEnv();
-    const Method = env.javaLangReflectMethod();
-    const invokeObjectMethodNoArgs = env.vaMethod('pointer', []);
 
-    const className = spec.name;
-    const interfaces = (spec.implements || []);
+    const localHandles = [];
+    try {
+      const Method = env.javaLangReflectMethod();
+      const invokeObjectMethodNoArgs = env.vaMethod('pointer', []);
 
-    const dexMethods = [];
-    const dexSpec = {
-      name: makeJniObjectTypeName(className),
-      sourceFileName: makeSourceFileName(className),
-      superClass: 'Ljava/lang/Object;',
-      interfaces: interfaces.map(iface => makeJniObjectTypeName(iface.$classWrapper.__name__)),
-      methods: dexMethods
-    };
+      const className = spec.name;
+      const interfaces = (spec.implements || []);
 
-    const pendingMethods = interfaces.reduce((result, iface) => {
-      const ifaceHandle = iface.$classHandle;
-      const ifaceProto = Object.getPrototypeOf(iface);
-      Object.getOwnPropertyNames(ifaceProto)
-        .filter(name => {
-          return name[0] !== '$' && name !== 'constructor' && name !== 'class';
-        })
-        .forEach(name => {
-          result[name] = [ifaceHandle, ifaceProto];
+      const dexMethods = [];
+      const dexSpec = {
+        name: makeJniObjectTypeName(className),
+        sourceFileName: makeSourceFileName(className),
+        superClass: 'Ljava/lang/Object;',
+        interfaces: interfaces.map(iface => makeJniObjectTypeName(iface.$classWrapper.__name__)),
+        methods: dexMethods
+      };
+
+      const pendingMethods = interfaces.reduce((result, iface) => {
+        const ifaceHandle = iface.$getClassHandle(env);
+        localHandles.push(ifaceHandle);
+        const ifaceProto = Object.getPrototypeOf(iface);
+        Object.getOwnPropertyNames(ifaceProto)
+          .filter(name => {
+            return name[0] !== '$' && name !== 'constructor' && name !== 'class';
+          })
+          .forEach(name => {
+            result[name] = [ifaceHandle, ifaceProto];
+          });
+        return result;
+      }, {});
+
+      const methods = spec.methods || {};
+      const methodNames = Object.keys(methods);
+      const numMethods = methodNames.length;
+
+      const nativeMethods = [];
+      const temporaryHandles = [];
+
+      let methodElements = null;
+
+      if (numMethods > 0) {
+        const methodElementSize = 3 * pointerSize;
+        methodElements = Memory.alloc(numMethods * methodElementSize);
+
+        methodNames.forEach((name, index) => {
+          const methodValue = methods[name];
+
+          let method = null;
+          let returnType;
+          let argumentTypes;
+          let thrownTypeNames = [];
+          let impl;
+
+          const m = pendingMethods[name];
+          if (m !== undefined) {
+            const [ifaceHandle, ifaceProto] = m;
+            delete pendingMethods[name];
+
+            if (typeof methodValue !== 'function') {
+              throw new Error('Expected a function for method: ' + name);
+            }
+            impl = methodValue;
+
+            method = ifaceProto[name];
+            const overloads = method.overloads;
+            if (overloads.length > 1) {
+              throw new Error('More than one overload matching: ' + name);
+            }
+            method = overloads[0];
+
+            returnType = method.returnType;
+            argumentTypes = method.argumentTypes;
+
+            const reflectedMethod = env.toReflectedMethod(ifaceHandle, method.handle, 0);
+            const thrownTypes = invokeObjectMethodNoArgs(env.handle, reflectedMethod, Method.getGenericExceptionTypes);
+            thrownTypeNames = readTypeNames(env, thrownTypes).map(makeJniObjectTypeName);
+            env.deleteLocalRef(thrownTypes);
+          } else if (typeof methodValue === 'function') {
+            returnType = getTypeFromJniTypeName('void');
+            argumentTypes = [];
+            impl = methodValue;
+          } else {
+            returnType = getTypeFromJniTypeName(methodValue.returnType || 'void');
+            argumentTypes = (methodValue.argumentTypes || []).map(name => getTypeFromJniTypeName(name));
+            impl = methodValue.implementation;
+            if (typeof impl !== 'function') {
+              throw new Error('Expected a function implementation for method: ' + name);
+            }
+          }
+
+          if (method === null) {
+            method = {
+              methodName: name,
+              type: INSTANCE_METHOD,
+              returnType: returnType,
+              argumentTypes: argumentTypes,
+              holder: placeholder
+            };
+            method[PENDING_CALLS] = new Set();
+          }
+
+          const returnTypeName = returnType.name;
+          const argumentTypeNames = argumentTypes.map(t => t.name);
+
+          dexMethods.push([name, returnTypeName, argumentTypeNames, thrownTypeNames]);
+
+          const signature = '(' + argumentTypeNames.join('') + ')' + returnTypeName;
+
+          const rawName = Memory.allocUtf8String(name);
+          const rawSignature = Memory.allocUtf8String(signature);
+          const rawImpl = implement(method, impl);
+
+          Memory.writePointer(methodElements.add(index * methodElementSize), rawName);
+          Memory.writePointer(methodElements.add((index * methodElementSize) + pointerSize), rawSignature);
+          Memory.writePointer(methodElements.add((index * methodElementSize) + (2 * pointerSize)), rawImpl);
+
+          temporaryHandles.push(rawName, rawSignature);
+          nativeMethods.push(rawImpl);
         });
-      return result;
-    }, {});
 
-    const methods = spec.methods || {};
-    const methodNames = Object.keys(methods);
-    const numMethods = methodNames.length;
-
-    const nativeMethods = [];
-    const temporaryHandles = [];
-
-    let methodElements = null;
-
-    if (numMethods > 0) {
-      const methodElementSize = 3 * pointerSize;
-      methodElements = Memory.alloc(numMethods * methodElementSize);
-
-      methodNames.forEach((name, index) => {
-        const methodValue = methods[name];
-
-        let method = null;
-        let returnType;
-        let argumentTypes;
-        let thrownTypeNames = [];
-        let impl;
-
-        const m = pendingMethods[name];
-        if (m !== undefined) {
-          const [ifaceHandle, ifaceProto] = m;
-          delete pendingMethods[name];
-
-          if (typeof methodValue !== 'function') {
-            throw new Error('Expected a function for method: ' + name);
-          }
-          impl = methodValue;
-
-          method = ifaceProto[name];
-          const overloads = method.overloads;
-          if (overloads.length > 1) {
-            throw new Error('More than one overload matching: ' + name);
-          }
-          method = overloads[0];
-
-          returnType = method.returnType;
-          argumentTypes = method.argumentTypes;
-
-          const reflectedMethod = env.toReflectedMethod(ifaceHandle, method.handle, 0);
-          const thrownTypes = invokeObjectMethodNoArgs(env.handle, reflectedMethod, Method.getGenericExceptionTypes);
-          thrownTypeNames = readTypeNames(env, thrownTypes).map(makeJniObjectTypeName);
-          env.deleteLocalRef(thrownTypes);
-        } else if (typeof methodValue === 'function') {
-          returnType = getTypeFromJniTypeName('void');
-          argumentTypes = [];
-          impl = methodValue;
-        } else {
-          returnType = getTypeFromJniTypeName(methodValue.returnType || 'void');
-          argumentTypes = (methodValue.argumentTypes || []).map(name => getTypeFromJniTypeName(name));
-          impl = methodValue.implementation;
-          if (typeof impl !== 'function') {
-            throw new Error('Expected a function implementation for method: ' + name);
-          }
+        const unimplementedMethodNames = Object.keys(pendingMethods);
+        if (unimplementedMethodNames.length > 0) {
+          throw new Error('Missing implementation for: ' + unimplementedMethodNames.join(', '));
         }
-
-        if (method === null) {
-          method = {
-            methodName: name,
-            type: INSTANCE_METHOD,
-            returnType: returnType,
-            argumentTypes: argumentTypes,
-            holder: placeholder
-          };
-          method[PENDING_CALLS] = new Set();
-        }
-
-        const returnTypeName = returnType.name;
-        const argumentTypeNames = argumentTypes.map(t => t.name);
-
-        dexMethods.push([name, returnTypeName, argumentTypeNames, thrownTypeNames]);
-
-        const signature = '(' + argumentTypeNames.join('') + ')' + returnTypeName;
-
-        const rawName = Memory.allocUtf8String(name);
-        const rawSignature = Memory.allocUtf8String(signature);
-        const rawImpl = implement(method, impl);
-
-        Memory.writePointer(methodElements.add(index * methodElementSize), rawName);
-        Memory.writePointer(methodElements.add((index * methodElementSize) + pointerSize), rawSignature);
-        Memory.writePointer(methodElements.add((index * methodElementSize) + (2 * pointerSize)), rawImpl);
-
-        temporaryHandles.push(rawName, rawSignature);
-        nativeMethods.push(rawImpl);
-      });
-
-      const unimplementedMethodNames = Object.keys(pendingMethods);
-      if (unimplementedMethodNames.length > 0) {
-        throw new Error('Missing implementation for: ' + unimplementedMethodNames.join(', '));
       }
+
+      const dexFile = DexFile.fromBuffer(mkdex(dexSpec));
+      dexFile.load();
+
+      const Klass = factory.use(spec.name);
+      Klass.$nativeMethods = nativeMethods;
+
+      if (numMethods > 0) {
+        const classHandle = Klass.$getClassHandle(env);
+        localHandles.push(classHandle);
+        env.registerNatives(classHandle, methodElements, numMethods);
+        env.checkForExceptionAndThrowIt();
+      }
+
+      const C = classes[spec.name];
+
+      function placeholder (...args) {
+        return new C(...args);
+      }
+
+      return Klass;
+    } finally {
+      localHandles.forEach(handle => {
+        env.deleteLocalRef(handle);
+      });
     }
-
-    const dexFile = DexFile.fromBuffer(mkdex(dexSpec));
-    dexFile.load();
-
-    const Klass = factory.use(spec.name);
-    Klass.$nativeMethods = nativeMethods;
-
-    if (numMethods > 0) {
-      env.registerNatives(Klass.$classHandle, methodElements, numMethods);
-      env.checkForExceptionAndThrowIt();
-    }
-
-    const C = classes[spec.name];
-
-    function placeholder (...args) {
-      return new C(...args);
-    }
-    placeholder.__handle__ = Klass.__handle__;
-
-    return Klass;
   }
 
   function makeSourceFileName (className) {
@@ -1621,7 +1745,7 @@ function ClassFactory (vm) {
       'if (env.pushLocalFrame(' + frameCapacity + ') !== JNI_OK) {' +
       'return;' +
       '}' +
-      'var self = ' + ((type === INSTANCE_METHOD) ? 'new C(C.__handle__, thisHandle);' : 'new C(thisHandle, null);') +
+      'var self = ' + ((type === INSTANCE_METHOD) ? 'new C(thisHandle);' : 'new C(null);') +
       'var result;' +
       'var tid = Process.getCurrentThreadId();' +
       'try {' +
@@ -1897,7 +2021,7 @@ function getObjectType (typeName, unbox, factory) {
         return null;
       } else if (typeName === 'java.lang.String' && unbox) {
         return env.stringFromJni(h);
-      } else if (this && this.$handle !== null && env.isSameObject(h, this.$handle)) {
+      } else if (this && this.$handle !== undefined && env.isSameObject(h, this.$handle)) {
         return this;
       } else {
         return factory.cast(h, factory.use(typeName));
@@ -2069,15 +2193,8 @@ function getArrayType (typeName, unbox, factory) {
           });
         },
         toJni: function (elements, env) {
-          let classHandle, klassObj;
-
-          const loader = factory.loader;
-          if (loader !== null) {
-            klassObj = factory.use(elementTypeName);
-            classHandle = klassObj.$classHandle;
-          } else {
-            classHandle = env.findClass(elementTypeName.replace(/\./g, '/'));
-          }
+          const klassObj = factory.use(elementTypeName);
+          const classHandle = klassObj.$getClassHandle(env);
 
           try {
             return toJniObjectArray(elements, env, classHandle,
@@ -2092,12 +2209,7 @@ function getArrayType (typeName, unbox, factory) {
                 }
               });
           } finally {
-            if (loader !== null) {
-              classHandle = null;
-              klassObj = null;
-            } else {
-              env.deleteLocalRef(classHandle);
-            }
+            env.deleteLocalRef(classHandle);
           }
         }
       };

--- a/lib/env.js
+++ b/lib/env.js
@@ -262,6 +262,10 @@ Env.prototype.isAssignableFrom = proxy(11, 'uint8', ['pointer', 'pointer', 'poin
   return !!impl(this.handle, klass1, klass2);
 });
 
+Env.prototype.toReflectedField = proxy(12, 'pointer', ['pointer', 'pointer', 'pointer', 'uint8'], function (impl, klass, fieldId, isStatic) {
+  return impl(this.handle, klass, fieldId, isStatic);
+});
+
 Env.prototype.throw = proxy(13, 'int32', ['pointer', 'pointer'], function (impl, obj) {
   return impl(this.handle, obj);
 });


### PR DESCRIPTION
This means we no longer use one global reference per class, and M + N
additional references for a class with M method and N fields.

The only long-lived global references we keep now are for instances, but
those are unavoidable. (And may be .dispose()d manually when desired.)