### PR TITLE
Ensure that an Array was received in toJniObjectArray()

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -2241,6 +2241,11 @@ function toJniObjectArray (arr, env, classHandle, setObjectArrayFunc) {
   if (arr === null) {
     return NULL;
   }
+
+  if (!(arr instanceof Array)) {
+    throw new Error("Expected an array.");
+  }
+
   const length = arr.length;
   const result = env.newObjectArray(length, classHandle, NULL);
 


### PR DESCRIPTION
If a function prototype expects an array, currently, it may be hard to debug this as an exception is thrown relatively deep in the call stack.

To demonstrate this, I set a frida-java playground as detailed [here](https://gist.github.com/oleavr/cae76c895eb7d227216ed3ffe9dbbeb3), with the following invalid sample code:

```js
Java.perform(function () {

    var X509TrustManager = Java.use('javax.net.ssl.X509TrustManager');
    var SSLContext = Java.use('javax.net.ssl.SSLContext');

    var SSLContext_init = SSLContext.init.overload('[Ljavax.net.ssl.KeyManager;',
        '[Ljavax.net.ssl.TrustManager;', 'java.security.SecureRandom')

    var TrustManager = Java.registerClass({
        name: 'com.example.test.TrustManager',
        implements: [X509TrustManager],
        methods: {
            checkClientTrusted: function (chain, authType) {
            },
            checkServerTrusted: function (chain, authType) {
            },
            getAcceptedIssuers: function () {
                return [];
            }
        }
    });

    var manager = TrustManager.$new();

    SSLContext_init.implementation = function (a, b, c) {

        SSLContext_init.call(this, a, manager, c);
    }
});

```

Running this hook, the `registerClass()` implementation runs fine, as well as the call to create a `$new()` one. However, once the hooked `init()` implementation is run, the following error occurs:

```
Error: expected number
    at Env.<anonymous> (../lib/env.js:363:10)
    at Env.newObjectArray (../lib/env.js:201:20)
    at toJniObjectArray (../lib/class-factory.js:2245:22)
    at SSLContext.toJni (../lib/class-factory.js:2200:20)
    at SSLContext.init (eval at makeMethod (../lib/class-factory.js:1226:7), <anonymous>:1:387)
    at SSLContext_init.implementation (agent/index.js:39:7)
    at init (eval at implement (../lib/class-factory.js:1743:5), <anonymous>:1:244)
```

Fixing the hook is a matter of providing and array as expected in the second argument instead of the single `TrustManager` that is returned from the call to `$new()`.

With this check added to ensure that `toJniObjectArray()` received an array as expected, the invalid implementation would rather fail earlier, with an error such as:

```
Error: Expected an array
    at toJniObjectArray (../lib/class-factory.js:2246:11)
    at SSLContext.toJni (repl1.js:5215:20)
    at SSLContext.init (eval at makeMethod (repl1.js:4272:7), <anonymous>:1:387)
    at SSLContext_init.implementation (agent/index.js:39:7)
    at init (eval at implement (repl1.js:4771:5), <anonymous>:1:244)
```