### PR TITLE
Update android.js - fixes #45

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -48,9 +48,17 @@ function _getApi () {
       // Android >= 6
       '_ZN3art9JavaVMExt12AddGlobalRefEPNS_6ThreadEPNS_6mirror6ObjectE': ['art::JavaVMExt::AddGlobalRef', 'pointer', ['pointer', 'pointer', 'pointer']],
       // Android < 6: makeAddGlobalRefFallbackForAndroid5() needs these:
-      '_ZN3art22IndirectReferenceTable3AddEjPNS_6mirror6ObjectE': ['art::IndirectReferenceTable::Add', 'pointer', ['pointer', 'uint', 'pointer']],
       '_ZN3art17ReaderWriterMutex13ExclusiveLockEPNS_6ThreadE': ['art::ReaderWriterMutex::ExclusiveLock', 'void', ['pointer', 'pointer']],
       '_ZN3art17ReaderWriterMutex15ExclusiveUnlockEPNS_6ThreadE': ['art::ReaderWriterMutex::ExclusiveUnlock', 'void', ['pointer', 'pointer']],
+
+      // Android <= 7
+      '_ZN3art22IndirectReferenceTable3AddEjPNS_6mirror6ObjectE' : function (address) {
+        this['art::IndirectReferenceTable::Add'] = new NativeFunction(address, 'pointer', ['pointer', 'uint', 'pointer']);
+      },
+      // Android > 7
+      '_ZN3art22IndirectReferenceTable3AddENS_15IRTSegmentStateENS_6ObjPtrINS_6mirror6ObjectEEE' : function (address) {
+        this['art::IndirectReferenceTable::Add'] = new NativeFunction(address, 'pointer', ['pointer', 'uint', 'pointer']);
+      },
 
       // Android >= 7
       '_ZN3art9JavaVMExt12DecodeGlobalEPv': function (address) {
@@ -122,7 +130,9 @@ function _getApi () {
       '_ZNK3art11ClassLinker17VisitClassLoadersEPNS_18ClassLoaderVisitorE',
       '_ZN3art6mirror6Object5CloneEPNS_6ThreadE',
       '_ZN3art6mirror6Object5CloneEPNS_6ThreadEm',
-      '_ZN3art6mirror6Object5CloneEPNS_6ThreadEj'
+      '_ZN3art6mirror6Object5CloneEPNS_6ThreadEj',
+      '_ZN3art22IndirectReferenceTable3AddEjPNS_6mirror6ObjectE',
+      '_ZN3art22IndirectReferenceTable3AddENS_15IRTSegmentStateENS_6ObjPtrINS_6mirror6ObjectEEE'
     ]
   }] : [{
     module: vmModule.path,


### PR DESCRIPTION
fixes #45
Added support for API 26 (Android 8). Not a 100% sure if this will function correctly when Android 9 arrives, since the method 'art::IndirectReferenceTable::Add' is now declared as optional, but this does work for API 25 & API 26.