### PR TITLE
memoize only when the computed value is not null fixes #53

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -612,9 +612,10 @@ function memoize (compute) {
   return function (...args) {
     if (!computed) {
       value = compute(...args);
-      computed = true;
+      if(value != null) {
+        computed = true;
+      }
     }
-
     return value;
   };
 }


### PR DESCRIPTION
The getApi function was getting memoize for the return value `null` as mentioned in the issue #53. This PR checks if the returned value of the compute function is null or not and if it is then doesn't memoize.
