### PR TITLE
Forward changes to array elements through hook methods

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -2550,25 +2550,49 @@ function fromJniPrimitiveArray (arr, typeName, env, getArrayLengthFunc, getArray
   if (arr.isNull()) {
     return null;
   }
-  const result = [];
+  const result = {};
   const type = getType(typeName, true, factory);
   const length = getArrayLengthFunc.call(env, arr);
-  const cArr = getArrayElementsFunc.call(env, arr);
-  if (cArr.isNull()) {
-    throw new Error("Can't get the array elements.");
-  }
-  try {
-    const offset = type.byteSize;
-    for (let i = 0; i < length; i++) {
-      const value = type.memoryRead(cArr.add(i * offset));
-      if (type.fromJni) {
-        result.push(type.fromJni(value));
-      } else {
-        result.push(value);
-      }
-    }
-  } finally {
-    releaseArrayElementsFunc.call(env, arr, cArr);
+  Object.defineProperty(result, 'length', {value: length});
+  Object.defineProperty(result, 'backingJavaArray', {value:arr});
+  const offset = type.byteSize;
+  for(let i = 0; i < length; i++) {
+    (function(i) {
+      Object.defineProperty(result, i, {
+        enumerable: true,
+        get: function() {
+          const cArr = getArrayElementsFunc.call(env, arr);
+          if(cArr.isNull()) {
+            throw new Error("Can't get the array elements.");
+          }
+          try {
+            const value = type.memoryRead(cArr.add(i * offset));
+            if(type.fromJni) {
+              return type.fromJni(value);
+            } else {
+              return value;
+            }
+          } finally {
+            releaseArrayElementsFunc.call(env, arr, cArr);
+          }
+        },
+        set: function(newValue) {
+          const cArr = getArrayElementsFunc.call(env, arr);
+          if(cArr.isNull()) {
+            throw new Error("Can't get the array elements.");
+          }
+          try {
+            if(type.toJni) {
+              type.memoryWrite(cArr.add(i * offset), type.toJni(newValue));
+            } else {
+              type.memoryWrite(cArr.add(i * offset), newValue);
+            }
+          } finally {
+            releaseArrayElementsFunc.call(env, arr, cArr);
+          }
+        }
+      });
+    })(i);
   }
 
   return result;
@@ -2577,6 +2601,9 @@ function fromJniPrimitiveArray (arr, typeName, env, getArrayLengthFunc, getArray
 function toJniPrimitiveArray (arr, typeName, env, newArrayFunc, setArrayFunc, factory) {
   if (arr === null) {
     return NULL;
+  }
+  if (arr.backingJavaArray) {
+    return arr.backingJavaArray
   }
   const length = arr.length;
   const type = getType(typeName, true, factory);


### PR DESCRIPTION
Copying arrays when converting between JNI and JS stops any changes made on the JS side from propagating into the JVM. This can be a problem if the method you're hooking is responsible for filling in an array that's passed in as a parameter (and you're still delegating to that method, rather than replacing it completely.)

Proposed fix is to convert a JNI array into a JS array-like object that acts as a proxy rather than a clone. Property access to array indices access the backing JNI array; a `length` attribute rounds out the array-like interface; and the backing JNI array is stored as a property in order to convert back from JS to JNI.