### PR TITLE
Allow hooking of java.lang.Class.getMethod

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -1267,7 +1267,7 @@ function ClassFactory (vm) {
             env.deleteLocalRef(retType);
           }
 
-          const argTypes = invokeObjectMethodNoArgs(env.handle, handle, Method.getGenericParameterTypes);
+          const argTypes = invokeObjectMethodNoArgs(env.handle, handle, Method.getParameterTypes);
           env.checkForExceptionAndThrowIt();
           try {
             const numArgTypes = env.getArrayLength(argTypes);

--- a/lib/env.js
+++ b/lib/env.js
@@ -674,6 +674,7 @@ Env.prototype.javaLangReflectMethod = function () {
       javaLangReflectMethod = {
         getName: this.getMethodId(handle, 'getName', '()Ljava/lang/String;'),
         getGenericParameterTypes: this.getMethodId(handle, 'getGenericParameterTypes', '()[Ljava/lang/reflect/Type;'),
+        getParameterTypes: this.getMethodId(handle, 'getParameterTypes', '()[Ljava/lang/Class;'),
         getGenericReturnType: this.getMethodId(handle, 'getGenericReturnType', '()Ljava/lang/reflect/Type;'),
         getGenericExceptionTypes: this.getMethodId(handle, 'getGenericExceptionTypes', '()[Ljava/lang/reflect/Type;'),
         getModifiers: this.getMethodId(handle, 'getModifiers', '()I'),


### PR DESCRIPTION
Hi Ole André Vadla Ravnås,

I was trying to use this dereflection script from https://codeshare.frida.re/@dzonerzy/dereflector/

Unfortunately it was not working (Abort !).

I noticed that the prototype from `java.lang.Class.getMethod` set in the script was not the expected one (second parameter shall be `[java.lang.Class;` instead of `[java.lang.Object;`) but when I tried to set the correct type, frida said that it could not find the overload.

I tried to correct the problem in `frida-java` by calling `getParameterTypes` instead of `getGenericParameterTypes` and it seems to work.

Please find enclosed the modified dereflector script : [dereflector.js.gz](https://github.com/frida/frida-java/files/2167320/dereflector.js.gz)

As I am not very familiar with the internals of frida, I would like to have your point of view on this correction.

Best regards,
Dr Zoidberg
