### PR TITLE
Changed ClassLinker discovery to properly track it on Android 8.0

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -360,7 +360,7 @@ function _getArtRuntimeSpec (api) {
     const value = Memory.readPointer(runtime.add(offset));
     if (value.equals(vm)) {
       let classLinkerOffset = offset - STD_STRING_SIZE - (2 * pointerSize);
-      if (apiLevel >= 27) {
+      if (apiLevel >= 26) {
         classLinkerOffset -= pointerSize;
       }
       const internTableOffset = classLinkerOffset - pointerSize;


### PR DESCRIPTION
Fix "Unable to determine ClassLinker field offsets" on Android 8.0