### PR TITLE
Fixing problems related to android runtime and hook on system_server

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,8 +304,14 @@ function Runtime () {
             const ActivityThread = classFactory.use('android.app.ActivityThread');
             const app = ActivityThread.currentApplication();
             if (app !== null) {
+              const Process = classFactory.use('android.os.Process');
               classFactory.loader = app.getClassLoader();
-              classFactory.cacheDir = app.getCacheDir().getCanonicalPath();
+
+              if (Process.myUid() === Process.SYSTEM_UID.value) {
+                classFactory.cacheDir = '/data/system';
+              } else {
+                classFactory.cacheDir = app.getCacheDir().getCanonicalPath();
+              }
               performPending(); // already initialized, continue
             } else {
               const m = ActivityThread.getPackageInfoNoCheck;

--- a/lib/android.js
+++ b/lib/android.js
@@ -360,7 +360,7 @@ function _getArtRuntimeSpec (api) {
     const value = Memory.readPointer(runtime.add(offset));
     if (value.equals(vm)) {
       let classLinkerOffset = offset - STD_STRING_SIZE - (2 * pointerSize);
-      if (apiLevel >= 26) {
+      if (apiLevel >= 27) {
         classLinkerOffset -= pointerSize;
       }
       const internTableOffset = classLinkerOffset - pointerSize;


### PR DESCRIPTION
This PR is rolling back the apiLevel comparison that aligns correctly the classLinkerOffset on Android 8.0 and 8.1.

This is fixing the problem with the cache dir when hooking system_server as well.