### PR TITLE
Fix return value handling for strings

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -2445,7 +2445,7 @@ function getJavaLangObjectType (factory) {
 function getAnyObjectType (typeName, unbox, factory) {
   let cachedClass = null;
   let cachedIsInstance = null;
-  let cachedIsCharSequence = null;
+  let cachedIsDefaultString = null;
 
   function getClass () {
     if (cachedClass === null) {
@@ -2464,11 +2464,11 @@ function getAnyObjectType (typeName, unbox, factory) {
     return cachedIsInstance.call(klass, v);
   }
 
-  function typeIsCharacterSequence () {
-    if (cachedIsCharSequence === null) {
-      cachedIsCharSequence = factory.use('java.lang.CharSequence').class.isAssignableFrom(getClass());
+  function typeIsDefaultString () {
+    if (cachedIsDefaultString === null) {
+      cachedIsDefaultString = factory.use('java.lang.String').class.isAssignableFrom(getClass());
     }
-    return cachedIsCharSequence;
+    return cachedIsDefaultString;
   }
 
   return {
@@ -2482,7 +2482,7 @@ function getAnyObjectType (typeName, unbox, factory) {
 
       const jsType = typeof v;
 
-      if (jsType === 'string' && typeIsCharacterSequence()) {
+      if (jsType === 'string' && typeIsDefaultString()) {
         return true;
       }
 
@@ -2498,7 +2498,7 @@ function getAnyObjectType (typeName, unbox, factory) {
         return null;
       }
 
-      if (typeIsCharacterSequence() && unbox) {
+      if (typeIsDefaultString() && unbox) {
         return env.stringFromJni(h);
       }
 


### PR DESCRIPTION
it should also fix: #87, which happens when `GetStringUTFChars` is invoked.
[Reference](https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#string_operations)
