### PR TITLE
Fix frida issue #700, frida-java not support Android 9

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -476,7 +476,7 @@ function _getArtMethodSpec (vm) {
 
     const entrypointFieldSize = (apiLevel <= 21) ? 8 : pointerSize;
 
-    const expectedAccessFlags = kAccPublic | kAccStatic | kAccFinal | kAccNative;
+    const expectedAccessFlags = kAccPublic | kAccStatic | kAccFinal | kAccNative | (apiLevel >= 28 ? kAccPublicApi : 0);
 
     let jniCodeOffset = null;
     let accessFlagsOffset = null;


### PR DESCRIPTION
Fixes https://github.com/frida/frida/issues/700

Android 9 started flagging native functions as PublicAPI or HiddenAPI in an attempt to prevent hidden API abuse.

Fortunately, the setArgv0 is a PublicAPI function, and is flagged as such now.

