### PR TITLE
Adding missing STD_VECTOR_SIZE definition.

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -16,6 +16,7 @@ const ENV_VTABLE_OFFSET_EXCEPTION_CLEAR = 17 * pointerSize;
 const ENV_VTABLE_OFFSET_FATAL_ERROR = 18 * pointerSize;
 
 const STD_STRING_SIZE = 3 * pointerSize;
+const STD_VECTOR_SIZE = 3 * pointerSize;
 
 const AF_UNIX = 1;
 const SOCK_STREAM = 1;


### PR DESCRIPTION
sizeof(std::vector<int>) returned 24 on my 64-bit build, and 12 on 32-bit. So ti's the same as STD_STRING_SIZE, 3 pointers, begin, end, capacity.