### PR TITLE
Enable add fields to registerClass() of Issue #76

### DIFF
--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -1786,12 +1786,14 @@ function ClassFactory (vm) {
       const interfaces = (spec.implements || []);
       const superClass = (spec.superClass || factory.use('java.lang.Object'));
 
+      const dexFields = [];
       const dexMethods = [];
       const dexSpec = {
         name: makeJniObjectTypeName(className),
         sourceFileName: makeSourceFileName(className),
         superClass: makeJniObjectTypeName(superClass.$classWrapper.__name__),
         interfaces: interfaces.map(iface => makeJniObjectTypeName(iface.$classWrapper.__name__)),
+        fields: dexFields,
         methods: dexMethods
       };
 
@@ -1802,6 +1804,12 @@ function ClassFactory (vm) {
             const baseIfaceName = Java.cast(baseIface, Class).getCanonicalName();
             allInterfaces.push(factory.use(baseIfaceName));
           });
+      });
+
+      const fields = spec.fields || {};
+      Object.getOwnPropertyNames(fields).forEach(name => {
+        const fieldType = getTypeFromJniTypeName(fields[name]);
+        dexFields.push([name, fieldType.name]);
       });
 
       const baseMethods = {};

--- a/lib/class-factory.js
+++ b/lib/class-factory.js
@@ -1877,7 +1877,7 @@ function ClassFactory (vm) {
               delete pendingOverloads[overloadIds[0]];
               const overload = baseMethod.overloads[0];
 
-              method = overload;
+              method = Object.assign({}, overload, { holder: placeholder });
               returnType = overload.returnType;
               argumentTypes = overload.argumentTypes;
               impl = methodValue;
@@ -1905,7 +1905,7 @@ function ClassFactory (vm) {
               const [overload, parentTypeHandle] = pendingOverload;
               delete pendingOverloads[id];
 
-              method = overload;
+              method = Object.assign({}, overload, { holder: placeholder });
 
               const reflectedMethod = env.toReflectedMethod(parentTypeHandle, overload.handle, 0);
               const thrownTypes = invokeObjectMethodNoArgs(env.handle, reflectedMethod, Method.getGenericExceptionTypes);

--- a/lib/mkdex.js
+++ b/lib/mkdex.js
@@ -435,7 +435,7 @@ class DexBuilder {
 }
 
 function makeClassData (klass, constructorCodeOffset) {
-  const {constructorMethod, virtualMethods, instanceFields} = klass.classData;
+  const {instanceFields, constructorMethod, virtualMethods} = klass.classData;
 
   const staticFieldsSize = 0;
   const instanceFieldsSize = instanceFields.length;
@@ -733,6 +733,8 @@ function computeModel (classes) {
       annotationDirectories.push(annotationsDirectory);
     }
 
+    const instanceFields = fieldItems.map((field, index) => [index, kAccPublic]);
+
     const constructorNameIndex = stringToIndex['<init>'];
     const constructorMethod = classMethods
       .filter(([, name]) => name === constructorNameIndex)
@@ -752,13 +754,12 @@ function computeModel (classes) {
       .map(([index]) => {
         return [index, kAccPublic | kAccNative];
       }));
-    const instanceFields = fieldItems.map((field, index) => [index, kAccPublic]);
 
     const classData = {
+      instanceFields,
       constructorMethod,
       superConstructorMethod,
       virtualMethods,
-      instanceFields,
       offset: -1
     };
 

--- a/lib/mkdex.js
+++ b/lib/mkdex.js
@@ -11,6 +11,7 @@ const kEndianTag = 0x12345678;
 
 const kClassDefSize = 32;
 const kProtoIdSize = 12;
+const kFieldIdSize = 8;
 const kMethodIdSize = 8;
 const kTypeIdSize = 4;
 const kStringIdSize = 4;
@@ -20,6 +21,7 @@ const TYPE_HEADER_ITEM = 0;
 const TYPE_STRING_ID_ITEM = 1;
 const TYPE_TYPE_ID_ITEM = 2;
 const TYPE_PROTO_ID_ITEM = 3;
+const TYPE_FIELD_ID_ITEM = 4;
 const TYPE_METHOD_ID_ITEM = 5;
 const TYPE_CLASS_DEF_ITEM = 6;
 const TYPE_MAP_LIST = 0x1000;
@@ -69,6 +71,7 @@ class DexBuilder {
     const {
       classes,
       interfaces,
+      fields,
       methods,
       protos,
       parameters,
@@ -100,8 +103,9 @@ class DexBuilder {
     const protoIdsSize = protos.length * kProtoIdSize;
     offset += protoIdsSize;
 
-    const fieldIdsOffset = 0;
-    const fieldIdsCount = 0;
+    const fieldIdsOffset = offset;
+    const fieldIdsSize = fields.length * kFieldIdSize;
+    offset += fieldIdsSize;
 
     const methodIdsOffset = offset;
     const methodIdsSize = methods.length * kMethodIdSize;
@@ -203,7 +207,7 @@ class DexBuilder {
     offset = align(offset, 4);
     const mapOffset = offset;
     const typeListLength = interfaces.length + parameters.length;
-    const mapNumItems = 8 + (3 * classes.length) + ((typeListLength > 0) ? 1 : 0) +
+    const mapNumItems = 8 + (3 * classes.length) + ((typeListLength > 0) ? 1 : 0) + ((fields.length > 0) ? 1 : 0) +
       annotationDirectories.length + annotationSets.length + throwsAnnotations.length;
     const mapSize = 4 + (mapNumItems * kMapItemSize);
     offset += mapSize;
@@ -228,8 +232,8 @@ class DexBuilder {
     dex.writeUInt32LE(typeIdsOffset, 0x44);
     dex.writeUInt32LE(protos.length, 0x48);
     dex.writeUInt32LE(protoIdsOffset, 0x4c);
-    dex.writeUInt32LE(fieldIdsCount, 0x50);
-    dex.writeUInt32LE(fieldIdsOffset, 0x54);
+    dex.writeUInt32LE(fields.length, 0x50);
+    dex.writeUInt32LE(fields.length > 0 ? fieldIdsOffset : 0, 0x54);
     dex.writeUInt32LE(methods.length, 0x58);
     dex.writeUInt32LE(methodIdsOffset, 0x5c);
     dex.writeUInt32LE(classes.length, 0x60);
@@ -252,6 +256,15 @@ class DexBuilder {
       dex.writeUInt32LE(shortyIndex, protoOffset);
       dex.writeUInt32LE(returnTypeIndex, protoOffset + 4);
       dex.writeUInt32LE((params !== null) ? params.offset : 0, protoOffset + 8);
+    });
+
+    fields.forEach((field, index) => {
+      const [classIndex, typeIndex, nameIndex] = field;
+
+      const fieldOffset = fieldIdsOffset + (index * kFieldIdSize);
+      dex.writeUInt16LE(classIndex, fieldOffset);
+      dex.writeUInt16LE(typeIndex, fieldOffset + 2);
+      dex.writeUInt32LE(nameIndex, fieldOffset + 4);
     });
 
     methods.forEach((method, index) => {
@@ -373,9 +386,12 @@ class DexBuilder {
       [TYPE_STRING_ID_ITEM, strings.length, stringIdsOffset],
       [TYPE_TYPE_ID_ITEM, types.length, typeIdsOffset],
       [TYPE_PROTO_ID_ITEM, protos.length, protoIdsOffset],
-      [TYPE_METHOD_ID_ITEM, methods.length, methodIdsOffset],
-      [TYPE_CLASS_DEF_ITEM, classes.length, classDefsOffset],
     ];
+    if (fields.length > 0) {
+      mapItems.push([TYPE_FIELD_ID_ITEM, fields.length, fieldIdsOffset]);
+    }
+    mapItems.push([TYPE_METHOD_ID_ITEM, methods.length, methodIdsOffset]);
+    mapItems.push([TYPE_CLASS_DEF_ITEM, classes.length, classDefsOffset]);
     annotationSets.forEach((set, index) => {
       mapItems.push([TYPE_ANNOTATION_SET_ITEM, set.items.length, annotationSetOffsets[index]]);
     });
@@ -419,10 +435,10 @@ class DexBuilder {
 }
 
 function makeClassData (klass, constructorCodeOffset) {
-  const {constructorMethod, virtualMethods} = klass.classData;
+  const {constructorMethod, virtualMethods, instanceFields} = klass.classData;
 
   const staticFieldsSize = 0;
-  const instanceFieldsSize = 0;
+  const instanceFieldsSize = instanceFields.length;
   const directMethodsSize = 1;
 
   const [constructorIndex, constructorAccessFlags] = constructorMethod;
@@ -433,6 +449,11 @@ function makeClassData (klass, constructorCodeOffset) {
       directMethodsSize,
     ]
     .concat(createUleb128(virtualMethods.length))
+    .concat(instanceFields.reduce((result, [indexDiff, accessFlags]) => {
+      return result
+          .concat(createUleb128(indexDiff))
+          .concat(createUleb128(accessFlags));
+    }, []))
     .concat(createUleb128(constructorIndex))
     .concat(createUleb128(constructorAccessFlags))
     .concat(createUleb128(constructorCodeOffset))
@@ -466,6 +487,7 @@ function computeModel (classes) {
   const strings = new Set();
   const types = new Set();
   const protos = {};
+  const fields = [];
   const methods = [];
   const throwsAnnotations = {};
   const superConstructors = new Set();
@@ -486,6 +508,14 @@ function computeModel (classes) {
     klass.interfaces.forEach(iface => {
       strings.add(iface);
       types.add(iface);
+    });
+
+    klass.fields.forEach(field => {
+      const [fieldName, fieldType] = field;
+      strings.add(fieldName);
+      strings.add(fieldType);
+      types.add(fieldType);
+      fields.push([klass.name, fieldType, fieldName]);
     });
 
     klass.methods.forEach(method => {
@@ -605,6 +635,15 @@ function computeModel (classes) {
   }, {});
   const parameterItems = Object.keys(parameters).map(id => parameters[id]);
 
+  const fieldItems = fields.map(field => {
+    const [klass, fieldType, fieldName] = field;
+    return [
+      typeToIndex[klass],
+      typeToIndex[fieldType],
+      stringToIndex[fieldName]
+    ];
+  });
+
   const methodItems = methods.map(method => {
     const [klass, protoId, name, annotationsId] = method;
     return [
@@ -713,11 +752,13 @@ function computeModel (classes) {
       .map(([index]) => {
         return [index, kAccPublic | kAccNative];
       }));
+    const instanceFields = fieldItems.map((field, index) => [index, kAccPublic]);
 
     const classData = {
       constructorMethod,
       superConstructorMethod,
       virtualMethods,
+      instanceFields,
       offset: -1
     };
 
@@ -736,6 +777,7 @@ function computeModel (classes) {
   return {
     classes: classItems,
     interfaces: interfaceItems,
+    fields: fieldItems,
     methods: methodItems,
     protos: protoItems,
     parameters: parameterItems,

--- a/test/re/frida/ClassCreationTest.java
+++ b/test/re/frida/ClassCreationTest.java
@@ -311,7 +311,7 @@ public class ClassCreationTest {
         assertEquals(Arrays.equals(new String[] { "tasty", "sweet" }, fruit.getTags()), true);
     }
 
-    // Issue #76
+    // Issue #76/#133
     @Test
     public void classWithUserDefinedFieldsCanBeImplemented() throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
         loadScript("var Formatter = Java.use('re.frida.Formatter');" +
@@ -327,18 +327,16 @@ public class ClassCreationTest {
                 "      returnType: 'java.lang.String'," +
                 "      argumentTypes: ['int']," +
                 "      implementation: function (val) {" +
-                "        const self = Java.cast(this, UserDefinedFields);" +
-                "        const oldVal = self.fieldInt.value;" +
-                "        self.fieldInt.value = val;" +
+                "        const oldVal = this.fieldInt.value;" +
+                "        this.fieldInt.value = val;" +
                 "        return oldVal + ': ' + val;" +
                 "      }" +
                 "    }, {" +
                 "      returnType: 'java.lang.String'," +
                 "      argumentTypes: ['java.lang.String']," +
                 "      implementation: function (val) {" +
-                "        const self = Java.cast(this, UserDefinedFields);" +
-                "        const oldVal = self.fieldStr.value;" +
-                "        self.fieldStr.value = val;" +
+                "        const oldVal = this.fieldStr.value;" +
+                "        this.fieldStr.value = val;" +
                 "        return oldVal + ': ' + val;" +
                 "      }" +
                 "    }]" +

--- a/test/re/frida/ClassCreationTest.java
+++ b/test/re/frida/ClassCreationTest.java
@@ -25,8 +25,8 @@ public class ClassCreationTest {
     private static Class simplePrimitiveArrayClass = null;
     private static Class myOutputClass1 = null;
     private static Class myOutputClass2 = null;
-    private static Class userDefinedFieldClass = null;
     private static Class orangeClass = null;
+    private static Class userDefinedFieldClass = null;
 
     @Test
     public void simpleClassCanBeImplemented() throws ClassNotFoundException, InstantiationException, IllegalAccessException {
@@ -316,27 +316,27 @@ public class ClassCreationTest {
     public void classWithUserDefinedFieldsCanBeImplemented() throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
         loadScript("var Formatter = Java.use('re.frida.Formatter');" +
                 "var UserDefinedFields = Java.registerClass({" +
-                "  name: 're.frida.SimpleFormatter'," +
+                "  name: 're.frida.StatefulFormatter'," +
                 "  implements: [Formatter]," +
                 "  fields: {" +
-                "    fieldInt: 'int'," +
-                "    fieldStr: 'java.lang.String'," +
+                "    lastInt: 'int'," +
+                "    lastStr: 'java.lang.String'," +
                 "  }," +
                 "  methods: {" +
                 "    format: [{" +
                 "      returnType: 'java.lang.String'," +
                 "      argumentTypes: ['int']," +
                 "      implementation: function (val) {" +
-                "        const oldVal = this.fieldInt.value;" +
-                "        this.fieldInt.value = val;" +
+                "        const oldVal = this.lastInt.value;" +
+                "        this.lastInt.value = val;" +
                 "        return oldVal + ': ' + val;" +
                 "      }" +
                 "    }, {" +
                 "      returnType: 'java.lang.String'," +
                 "      argumentTypes: ['java.lang.String']," +
                 "      implementation: function (val) {" +
-                "        const oldVal = this.fieldStr.value;" +
-                "        this.fieldStr.value = val;" +
+                "        const oldVal = this.lastStr.value;" +
+                "        this.lastStr.value = val;" +
                 "        return oldVal + ': ' + val;" +
                 "      }" +
                 "    }]" +


### PR DESCRIPTION
I made an improvement for registerClass() to enable add user defined fields, such like below:

```
var UserDefinedFields = Java.registerClass({
  name: 're.frida.SimpleFormatter',
  implements: [Formatter],
  fields: {
    fieldInt: 'int',
    fieldStr: 'java.lang.String',
  },
  methods: {
    format: [{
      returnType: 'java.lang.String',
      argumentTypes: ['int'],
      implementation: function (val) {
        const self = Java.cast(this, UserDefinedFields);
        const oldVal = self.fieldInt.value;
        self.fieldInt.value = val;
        return oldVal + ': ' + val;
      }
    }, {
      returnType: 'java.lang.String',
      argumentTypes: ['java.lang.String'],
      implementation: function (val) {
        const self = Java.cast(this, UserDefinedFields);
        const oldVal = self.fieldStr.value;
        self.fieldStr.value = val;
        return oldVal + ': ' + val;
      }
    }]
  }
});
```